### PR TITLE
Add backslash character to escape underscores when using LIKE statements

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -237,7 +237,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT schema_name AS nspname
                 FROM   information_schema.schemata
-                WHERE  schema_name NOT LIKE 'pg_%'
+                WHERE  schema_name NOT LIKE 'pg\_%'
                 AND    schema_name != 'information_schema'";
     }
 
@@ -249,7 +249,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         return "SELECT sequence_name AS relname,
                        sequence_schema AS schemaname
                 FROM   information_schema.sequences
-                WHERE  sequence_schema NOT LIKE 'pg_%'
+                WHERE  sequence_schema NOT LIKE 'pg\_%'
                 AND    sequence_schema != 'information_schema'";
     }
 
@@ -261,7 +261,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         return "SELECT quote_ident(table_name) AS table_name,
                        table_schema AS schema_name
                 FROM   information_schema.tables
-                WHERE  table_schema NOT LIKE 'pg_%'
+                WHERE  table_schema NOT LIKE 'pg\_%'
                 AND    table_schema != 'information_schema'
                 AND    table_name != 'geometry_columns'
                 AND    table_name != 'spatial_ref_sys'


### PR DESCRIPTION
I created a Jira issue here: http://www.doctrine-project.org/jira/browse/DBAL-1229 about this problem. Basically you need to escape the underscores otherwise the schema queries ignore tables starting with pg, like "pglims". Thanks!
